### PR TITLE
Remove dependency on globally-installed tape executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.js",
   "type": "commonjs",
   "scripts": {
-    "test": "tape tests/*.test.js"
+    "test": "npx tape tests/*.test.js"
   },
   "bin": {
     "tap-in": "bin/tap-in.js"


### PR DESCRIPTION
This PR prefixes `npx` to the test command to remove the dependency on a globally-installed tape executable by calling the version in `/node_modules`.